### PR TITLE
Fix build error by adding rollup typescript plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "vite": "^4.0.0",
     "rollup": "^3.0.0",
+    "@rollup/plugin-typescript": "^11.1.0",
     "@vitejs/plugin-react": "^4.0.0",
     "vitest": "^0.34.0",
     "typescript": "^5.0.0",


### PR DESCRIPTION
## Summary
- add `@rollup/plugin-typescript` to devDependencies for rollup

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bad1e5c88321895e66341eb6695f