### PR TITLE
Fix rollup externals and avoid generic useRef

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,12 @@ export default defineConfig({
     file: 'dist/pptxjs-modern.min.js',
     format: 'umd',
     name: 'pptxjs',
+    globals: {
+      jszip: 'JSZip',
+      react: 'React',
+      d3: 'd3',
+      nvd3: 'nv',
+    },
     sourcemap: true,
   },
   external: ['jszip', 'd3', 'nvd3', 'react'],

--- a/src/react/PptViewer.tsx
+++ b/src/react/PptViewer.tsx
@@ -11,7 +11,8 @@ export interface PptViewerProps {
 }
 
 export function PptViewer({ fileUrl }: PptViewerProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
+  // Avoid generic parameters to keep compatibility when React types are missing
+  const containerRef = useRef(null);
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;


### PR DESCRIPTION
## Summary
- declare globals for Rollup externals
- remove generic parameter from `useRef` in `PptViewer` to avoid TypeScript error

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842be715a348321894261cf9699eeca