### PR TITLE
Fix example file not found error

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,9 @@ export default defineConfig({
     lib: {
       entry: 'src/index.ts',
       name: 'pptxjs-modern',
-      fileName: (format) => `pptxjs-modern.${format}.mjs`,
+      // Output filename needs to match "module" entry in package.json
+      // and example paths.
+      fileName: () => 'pptxjs-modern.mjs',
       formats: ['es'],
     },
     rollupOptions: {


### PR DESCRIPTION
## Summary
- ensure the build produces `pptxjs-modern.mjs`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842dfe065248321bc30794a886b5f58